### PR TITLE
fix error on "dbt docs " completion

### DIFF
--- a/_dbt
+++ b/_dbt
@@ -219,7 +219,7 @@ _dbt_docs() {
         '(-t --target)'{-t,--target}"[which target to load for the given profile]"  \
         --vars"[supply variables to the project - eg. '{my_variable: my_value}']:()" \
         --bypass-cache"[if set, bypass the adapter-level cache of database state]" \
-        --no-compile"[Do not run \"dbt compile\" as part of docs generation"
+        --no-compile"[Do not run \"dbt compile\" as part of docs generation]"
 }
 
 # Provides arguments for dbt test


### PR DESCRIPTION
fixes
```_arguments:comparguments:325: invalid option definition: --no-compile[Do not run "dbt compile" as part of docs generation```
error when typing `dbt docs <tab>`