### PR TITLE
fix: fix SyntaxWarning when using Python 3.12

### DIFF
--- a/_dbt
+++ b/_dbt
@@ -110,7 +110,7 @@ try:
     }
 
     selectors = [
-        selector.replace(':', '\:')
+        selector.replace(':', r'\:')
         for selector in (models | tags | sources | exposures | metrics | fqns | hard_coded)
         if selector != ''
     ]


### PR DESCRIPTION
Under Python 3.12, the completion currently prints errors:

```
 <string>:76: SyntaxWarning: invalid escape sequence '\:'
```

The reason is explained [here](https://stackoverflow.com/a/77531416/2429404). This PR removes the warnings.