### PR TITLE
Add fetching dbt project dir from environment variable

### DIFF
--- a/dbt-completion.bash
+++ b/dbt-completion.bash
@@ -194,7 +194,13 @@ _complete_it() {
     if [[ $is_selector == 0 ]] ; then
         current_arg="${COMP_WORDS[$COMP_CWORD]}"
         prefix=$(_get_arg_prefix $current_arg)
-        project_dir=$(_get_project_root)
+
+        # Attempt to fetch the project directory from the environment variable
+        if [ -z "$DBT_PROJECT_DIR" ] ; then
+            project_dir=$(_get_project_root)
+        else
+            project_dir="$DBT_PROJECT_DIR"
+        fi
 
         # Attempt to fetch the manifest path from the environment variable
         if [ -z "$DBT_MANIFEST_PATH" ] ; then


### PR DESCRIPTION
Dbt uses DBT_PROJECT_DIR to specify the dbt project location so one can run dbt run from anywhere.

This PR adds support for using that environment variable to find the dbt_project.yml if defined. Otherwise fallsback to the current behaviour.